### PR TITLE
State Management

### DIFF
--- a/src/main/java/tech/mayanksoni/threatdetectionbackend/configuration/ThreatDetectionConfig.java
+++ b/src/main/java/tech/mayanksoni/threatdetectionbackend/configuration/ThreatDetectionConfig.java
@@ -61,4 +61,9 @@ public class ThreatDetectionConfig {
      */
     @Builder.Default
     private int batchSize = 100;
+    /**
+     * The default state expires timestamp to be set
+     */
+    @Builder.Default
+    private String defaultStateLifetime = "24h";
 }

--- a/src/main/java/tech/mayanksoni/threatdetectionbackend/controller/v1/CheckDomainController.java
+++ b/src/main/java/tech/mayanksoni/threatdetectionbackend/controller/v1/CheckDomainController.java
@@ -62,7 +62,7 @@ public class CheckDomainController {
             @Parameter(description = "State UUID for the domain check", required = true)
             @RequestParam String stateId
     ) {
-        return domainCheckProcessor.checkDomain(domainName,stateId);
+        return domainCheckProcessor.checkDomain(domainName,stateId, null);
     }
 
     /**

--- a/src/main/java/tech/mayanksoni/threatdetectionbackend/controller/v1/CheckDomainController.java
+++ b/src/main/java/tech/mayanksoni/threatdetectionbackend/controller/v1/CheckDomainController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import tech.mayanksoni.threatdetectionbackend.models.DomainTyposquattingValidationResults;
+import tech.mayanksoni.threatdetectionbackend.models.DomainValidationResponse;
 import tech.mayanksoni.threatdetectionbackend.processor.DomainCheckProcessor;
 
 import java.util.List;
@@ -40,7 +41,7 @@ public class CheckDomainController {
                     description = "Domain validation completed successfully",
                     content = @Content(
                             mediaType = "application/json",
-                            schema = @Schema(implementation = DomainTyposquattingValidationResults.class)
+                            schema = @Schema(implementation = DomainValidationResponse.class)
                     )
             ),
             @ApiResponse(
@@ -55,10 +56,13 @@ public class CheckDomainController {
             )
     })
     @GetMapping
-    public Mono<DomainTyposquattingValidationResults> validateDomainForTyposquatting(
+    public Mono<DomainValidationResponse> validateDomainForTyposquatting(
             @Parameter(description = "Domain name to validate", required = true)
-            @RequestParam String domainName) {
-        return domainCheckProcessor.checkDomain(domainName);
+            @RequestParam String domainName,
+            @Parameter(description = "State UUID for the domain check", required = true)
+            @RequestParam String stateId
+    ) {
+        return domainCheckProcessor.checkDomain(domainName,stateId);
     }
 
     /**

--- a/src/main/java/tech/mayanksoni/threatdetectionbackend/controller/v1/CheckDomainController.java
+++ b/src/main/java/tech/mayanksoni/threatdetectionbackend/controller/v1/CheckDomainController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import tech.mayanksoni.threatdetectionbackend.models.DomainTyposquattingValidationResults;
+import tech.mayanksoni.threatdetectionbackend.models.DomainValidationRequest;
 import tech.mayanksoni.threatdetectionbackend.models.DomainValidationResponse;
 import tech.mayanksoni.threatdetectionbackend.processor.DomainCheckProcessor;
 
@@ -63,6 +64,36 @@ public class CheckDomainController {
             @RequestParam String stateId
     ) {
         return domainCheckProcessor.checkDomain(domainName,stateId, null);
+    }
+    @Operation(
+            summary = "Validate domain for typosquatting with POST",
+            description = "Checks if a domain is potentially a typosquatting attempt against trusted domains using POST method"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Domain validation completed successfully",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = DomainValidationResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "Invalid domain name format",
+                    content = @Content
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "Internal server error",
+                    content = @Content
+            )
+    })
+    @PostMapping
+    public Mono<DomainValidationResponse> validateDomainForTyposquattingPost(
+            @RequestBody DomainValidationRequest validationRequest
+            ){
+        return domainCheckProcessor.checkDomain(validationRequest.domainName(), validationRequest.stateId(), validationRequest.ipAddress());
     }
 
     /**

--- a/src/main/java/tech/mayanksoni/threatdetectionbackend/dm/StateDataManager.java
+++ b/src/main/java/tech/mayanksoni/threatdetectionbackend/dm/StateDataManager.java
@@ -5,7 +5,7 @@ import reactor.core.publisher.Mono;
 import tech.mayanksoni.threatdetectionbackend.models.StateModel;
 
 public interface StateDataManager {
-    Mono<StateModel> createState(String state, String domainName, String ipAddress, boolean accessOverrideControlAvailable);
+    Mono<StateModel> createState(String state, String domainName, String ipAddress, boolean accessOverrideControlAvailable, boolean accessAllowed);
     Flux<StateModel> getActiveStateByIpAddress(String ipAddress);
     Mono<StateModel> getStateById(String stateId);
     Mono<StateModel> updateStateById(String stateId, boolean accessAllowed);

--- a/src/main/java/tech/mayanksoni/threatdetectionbackend/dm/StateDataManager.java
+++ b/src/main/java/tech/mayanksoni/threatdetectionbackend/dm/StateDataManager.java
@@ -1,0 +1,18 @@
+package tech.mayanksoni.threatdetectionbackend.dm;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import tech.mayanksoni.threatdetectionbackend.models.StateModel;
+
+public interface StateDataManager {
+    Mono<StateModel> createState(String state, String domainName, String ipAddress, boolean accessOverrideControlAvailable);
+    Flux<StateModel> getActiveStateByIpAddress(String ipAddress);
+    Mono<StateModel> getStateById(String stateId);
+    Mono<StateModel> updateStateById(String stateId, boolean accessAllowed);
+    Flux<StateModel> getAllStates();
+    Flux<StateModel> getAllActiveStates();
+    void deleteStateById(String stateId);
+    void deleteAllStates();
+    Mono<Void> deleteAllInactiveStates();
+    void deleteAllActiveStates();
+}

--- a/src/main/java/tech/mayanksoni/threatdetectionbackend/dm/StateDataManager.java
+++ b/src/main/java/tech/mayanksoni/threatdetectionbackend/dm/StateDataManager.java
@@ -13,6 +13,6 @@ public interface StateDataManager {
     Flux<StateModel> getAllActiveStates();
     void deleteStateById(String stateId);
     void deleteAllStates();
-    Mono<Void> deleteAllInactiveStates();
+    void deleteAllInactiveStates();
     void deleteAllActiveStates();
 }

--- a/src/main/java/tech/mayanksoni/threatdetectionbackend/dm/impl/mongo/StateMongoDataManagerImpl.java
+++ b/src/main/java/tech/mayanksoni/threatdetectionbackend/dm/impl/mongo/StateMongoDataManagerImpl.java
@@ -6,6 +6,8 @@ import org.springframework.data.mongodb.core.ReactiveMongoTemplate;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.core.query.Update;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -20,11 +22,21 @@ import java.time.Instant;
 @Service
 @Slf4j
 @RequiredArgsConstructor
+@EnableScheduling
 public class StateMongoDataManagerImpl implements StateDataManager {
     private final ReactiveMongoTemplate mongoTemplate;
     private final ThreatDetectionConfig threatDetectionConfig;
-    private static final Query ACTIVE_STATES_QUERY = Query.query(Criteria.where("stateExpiresAt").lt(Instant.now()));
+    private static final Query ACTIVE_STATES_QUERY = Query.query(Criteria.where("stateExpiresAt").gt(Instant.now()));
+    private static final Query INACTIVE_STATES_QUERY = Query.query(Criteria.where("stateExpiresAt").lt(Instant.now()));
     private final StateMapper STATE_MAPPER;
+
+    @Scheduled(cron = "0 */5 * * * *")
+    private void performCleanupTask() {
+        // This method is a placeholder for any cleanup logic that might be needed every 15 minutes.
+        // It can be implemented as needed.
+        log.info("Performing cleanup task for state");
+        this.deleteAllInactiveStates();
+    }
     @Override
     public Mono<StateModel> createState(String state, String domainName, String ipAddress, boolean accessOverrideControlAvailable) {
         StateDocument stateDocument = StateDocument.builder()
@@ -95,8 +107,8 @@ public class StateMongoDataManagerImpl implements StateDataManager {
     }
 
     @Override
-    public Mono<Void> deleteAllInactiveStates() {
-        return null;
+    public void deleteAllInactiveStates() {
+        this.mongoTemplate.remove(INACTIVE_STATES_QUERY, StateDocument.class).doOnSuccess(result -> log.info("Successfully deleted {} inactive states",result.getDeletedCount())).subscribe();
     }
 
     @Override

--- a/src/main/java/tech/mayanksoni/threatdetectionbackend/dm/impl/mongo/StateMongoDataManagerImpl.java
+++ b/src/main/java/tech/mayanksoni/threatdetectionbackend/dm/impl/mongo/StateMongoDataManagerImpl.java
@@ -39,6 +39,10 @@ public class StateMongoDataManagerImpl implements StateDataManager {
         log.info("Performing cleanup task for state");
         this.deleteAllInactiveStates();
     }
+
+    private static Instant processTime(String timeString){
+        return TimeProcessor.processTime(timeString);
+    }
     @Override
     public Mono<StateModel> createState(String state, String domainName, String ipAddress, boolean accessOverrideControlAvailable) {
         StateDocument stateDocument = StateDocument.builder()
@@ -46,6 +50,7 @@ public class StateMongoDataManagerImpl implements StateDataManager {
                 .stateExpiresAt(TimeProcessor.processTime(threatDetectionConfig.getDefaultStateLifetime()))
                 .creationTimestamp(Instant.now())
                 .accessAllowed(false)
+                .stateExpiresAt(processTime(threatDetectionConfig.getDefaultStateLifetime()))
                 .accessOverrideControlAvailable(accessOverrideControlAvailable)
                 .domainName(domainName)
                 .ipAddress(ipAddress)
@@ -69,8 +74,8 @@ public class StateMongoDataManagerImpl implements StateDataManager {
 
     @Override
     public Mono<StateModel> updateStateById(String stateId, boolean accessAllowed) {
-        Query query = ACTIVE_STATES_QUERY.addCriteria(Criteria.where("id").is(stateId));
-        Update update = new Update().set("accessAllowed", accessAllowed).set("stateExpiresAt", TimeProcessor.processTime(threatDetectionConfig.getDefaultStateLifetime()));
+        Query query = ACTIVE_STATES_QUERY.addCriteria(Criteria.where("id").is(stateId).and("accessOverrideControlAvailable").is(false));
+        Update update = new Update().set("accessAllowed", accessAllowed).set("stateExpiresAt",processTime(threatDetectionConfig.getDefaultStateLifetime()));
         return this.mongoTemplate.updateFirst(query, update, StateDocument.class).flatMap(s -> {
             if (s.getModifiedCount() == 0) {
                 return Mono.error(new IllegalArgumentException("State not found with id: " + stateId));

--- a/src/main/java/tech/mayanksoni/threatdetectionbackend/dm/impl/mongo/StateMongoDataManagerImpl.java
+++ b/src/main/java/tech/mayanksoni/threatdetectionbackend/dm/impl/mongo/StateMongoDataManagerImpl.java
@@ -44,12 +44,12 @@ public class StateMongoDataManagerImpl implements StateDataManager {
         return TimeProcessor.processTime(timeString);
     }
     @Override
-    public Mono<StateModel> createState(String state, String domainName, String ipAddress, boolean accessOverrideControlAvailable) {
+    public Mono<StateModel> createState(String state, String domainName, String ipAddress, boolean accessOverrideControlAvailable, boolean accessAllowed) {
         StateDocument stateDocument = StateDocument.builder()
                 .id(state)
                 .stateExpiresAt(TimeProcessor.processTime(threatDetectionConfig.getDefaultStateLifetime()))
                 .creationTimestamp(Instant.now())
-                .accessAllowed(false)
+                .accessAllowed(accessAllowed)
                 .stateExpiresAt(processTime(threatDetectionConfig.getDefaultStateLifetime()))
                 .accessOverrideControlAvailable(accessOverrideControlAvailable)
                 .domainName(domainName)
@@ -66,10 +66,9 @@ public class StateMongoDataManagerImpl implements StateDataManager {
 
     @Override
     public Mono<StateModel> getStateById(String stateId) {
-        Query query = ACTIVE_STATES_QUERY.addCriteria(Criteria.where("id").is(stateId));
+        Query query = Query.query(Criteria.where("id").is(stateId));
         return mongoTemplate.findOne(query, StateDocument.class)
-                .map(STATE_MAPPER::toStateModel)
-                .switchIfEmpty(Mono.error(new IllegalArgumentException("State not found with id: " + stateId)));
+                .map(STATE_MAPPER::toStateModel);
     }
 
     @Override

--- a/src/main/java/tech/mayanksoni/threatdetectionbackend/dm/impl/mongo/StateMongoDataManagerImpl.java
+++ b/src/main/java/tech/mayanksoni/threatdetectionbackend/dm/impl/mongo/StateMongoDataManagerImpl.java
@@ -1,0 +1,106 @@
+package tech.mayanksoni.threatdetectionbackend.dm.impl.mongo;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.mongodb.core.ReactiveMongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import tech.mayanksoni.threatdetectionbackend.configuration.ThreatDetectionConfig;
+import tech.mayanksoni.threatdetectionbackend.dm.StateDataManager;
+import tech.mayanksoni.threatdetectionbackend.documents.StateDocument;
+import tech.mayanksoni.threatdetectionbackend.mappers.StateMapper;
+import tech.mayanksoni.threatdetectionbackend.models.StateModel;
+import tech.mayanksoni.threatdetectionbackend.utils.TimeProcessor;
+
+import java.time.Instant;
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class StateMongoDataManagerImpl implements StateDataManager {
+    private final ReactiveMongoTemplate mongoTemplate;
+    private final ThreatDetectionConfig threatDetectionConfig;
+    private static final Query ACTIVE_STATES_QUERY = Query.query(Criteria.where("stateExpiresAt").lt(Instant.now()));
+    private final StateMapper STATE_MAPPER;
+    @Override
+    public Mono<StateModel> createState(String state, String domainName, String ipAddress, boolean accessOverrideControlAvailable) {
+        StateDocument stateDocument = StateDocument.builder()
+                .id(state)
+                .stateExpiresAt(TimeProcessor.processTime(threatDetectionConfig.getDefaultStateLifetime()))
+                .creationTimestamp(Instant.now())
+                .accessAllowed(false)
+                .accessOverrideControlAvailable(accessOverrideControlAvailable)
+                .domainName(domainName)
+                .ipAddress(ipAddress)
+                .build();
+        return mongoTemplate.save(stateDocument).map(STATE_MAPPER::toStateModel);
+    }
+
+    @Override
+    public Flux<StateModel> getActiveStateByIpAddress(String ipAddress) {
+        Query query = ACTIVE_STATES_QUERY.addCriteria(Criteria.where("ipAddress").is(ipAddress));
+        return mongoTemplate.find(query, StateDocument.class).map(STATE_MAPPER::toStateModel);
+    }
+
+    @Override
+    public Mono<StateModel> getStateById(String stateId) {
+        Query query = ACTIVE_STATES_QUERY.addCriteria(Criteria.where("id").is(stateId));
+        return mongoTemplate.findOne(query, StateDocument.class)
+                .map(STATE_MAPPER::toStateModel)
+                .switchIfEmpty(Mono.error(new IllegalArgumentException("State not found with id: " + stateId)));
+    }
+
+    @Override
+    public Mono<StateModel> updateStateById(String stateId, boolean accessAllowed) {
+        Query query = ACTIVE_STATES_QUERY.addCriteria(Criteria.where("id").is(stateId));
+        Update update = new Update().set("accessAllowed", accessAllowed).set("stateExpiresAt", TimeProcessor.processTime(threatDetectionConfig.getDefaultStateLifetime()));
+        return this.mongoTemplate.updateFirst(query, update, StateDocument.class).flatMap(s -> {
+            if (s.getModifiedCount() == 0) {
+                return Mono.error(new IllegalArgumentException("State not found with id: " + stateId));
+            }
+            return getStateById(stateId);
+        });
+    }
+
+    @Override
+    public Flux<StateModel> getAllStates() {
+        return mongoTemplate.findAll(StateDocument.class).map(STATE_MAPPER::toStateModel);
+    }
+
+    @Override
+    public Flux<StateModel> getAllActiveStates() {
+        return mongoTemplate.find(ACTIVE_STATES_QUERY, StateDocument.class).map(STATE_MAPPER::toStateModel)
+                .switchIfEmpty(Mono.error(new IllegalArgumentException("No active states found")));
+    }
+
+    @Override
+    public void deleteStateById(String stateId) {
+        Query deleteSelectionQuery = Query.query(Criteria.where("id").is(stateId));
+       this.mongoTemplate.remove(deleteSelectionQuery, StateDocument.class)
+                .doOnSuccess(result -> {
+                    if (result.getDeletedCount() == 0) {
+                        log.warn("No state found with id: {}", stateId);
+                    } else {
+                        log.info("State with id {} deleted successfully", stateId);
+                    }
+                }).subscribe();
+    }
+
+    @Override
+    public void deleteAllStates() {
+        this.mongoTemplate.dropCollection(StateDocument.class).doOnSuccess(success -> log.info("Successfully deleted all states")).subscribe();
+    }
+
+    @Override
+    public Mono<Void> deleteAllInactiveStates() {
+        return null;
+    }
+
+    @Override
+    public void deleteAllActiveStates() {
+        this.mongoTemplate.remove(ACTIVE_STATES_QUERY, StateDocument.class).subscribe();
+    }
+}

--- a/src/main/java/tech/mayanksoni/threatdetectionbackend/dm/impl/mongo/StateMongoDataManagerImpl.java
+++ b/src/main/java/tech/mayanksoni/threatdetectionbackend/dm/impl/mongo/StateMongoDataManagerImpl.java
@@ -1,5 +1,6 @@
 package tech.mayanksoni.threatdetectionbackend.dm.impl.mongo;
 
+import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.mongodb.core.ReactiveMongoTemplate;
@@ -31,6 +32,7 @@ public class StateMongoDataManagerImpl implements StateDataManager {
     private final StateMapper STATE_MAPPER;
 
     @Scheduled(cron = "0 */5 * * * *")
+    @PostConstruct
     private void performCleanupTask() {
         // This method is a placeholder for any cleanup logic that might be needed every 15 minutes.
         // It can be implemented as needed.

--- a/src/main/java/tech/mayanksoni/threatdetectionbackend/dm/impl/mongo/TrustedDomainMongoDataManagerImpl.java
+++ b/src/main/java/tech/mayanksoni/threatdetectionbackend/dm/impl/mongo/TrustedDomainMongoDataManagerImpl.java
@@ -1,4 +1,4 @@
-package tech.mayanksoni.threatdetectionbackend.dm.impl;
+package tech.mayanksoni.threatdetectionbackend.dm.impl.mongo;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/tech/mayanksoni/threatdetectionbackend/documents/StateDocument.java
+++ b/src/main/java/tech/mayanksoni/threatdetectionbackend/documents/StateDocument.java
@@ -1,0 +1,27 @@
+package tech.mayanksoni.threatdetectionbackend.documents;
+
+import lombok.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.Instant;
+
+@Document
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class StateDocument {
+    @Id
+    private String id;
+    @Indexed
+    private String domainName;
+    @Indexed
+    private String ipAddress;
+    private Instant creationTimestamp;
+    private Instant stateExpiresAt;
+    private boolean accessOverrideControlAvailable;
+    private boolean accessAllowed;
+}

--- a/src/main/java/tech/mayanksoni/threatdetectionbackend/mappers/StateMapper.java
+++ b/src/main/java/tech/mayanksoni/threatdetectionbackend/mappers/StateMapper.java
@@ -1,0 +1,13 @@
+package tech.mayanksoni.threatdetectionbackend.mappers;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingConstants;
+import tech.mayanksoni.threatdetectionbackend.documents.StateDocument;
+import tech.mayanksoni.threatdetectionbackend.models.StateModel;
+
+@Mapper(componentModel = MappingConstants.ComponentModel.SPRING)
+public interface StateMapper {
+    @Mapping(source = "id", target = "state")
+    StateModel toStateModel(StateDocument stateDocument);
+}

--- a/src/main/java/tech/mayanksoni/threatdetectionbackend/models/DomainValidationRequest.java
+++ b/src/main/java/tech/mayanksoni/threatdetectionbackend/models/DomainValidationRequest.java
@@ -1,0 +1,8 @@
+package tech.mayanksoni.threatdetectionbackend.models;
+
+public record DomainValidationRequest(
+        String domainName,
+        String stateId,
+        String ipAddress
+) {
+}

--- a/src/main/java/tech/mayanksoni/threatdetectionbackend/models/DomainValidationResponse.java
+++ b/src/main/java/tech/mayanksoni/threatdetectionbackend/models/DomainValidationResponse.java
@@ -1,0 +1,14 @@
+package tech.mayanksoni.threatdetectionbackend.models;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Schema(description = "Response for domain validation")
+@Builder
+public record DomainValidationResponse(
+        @Schema(description = "The state of the domain")
+        StateModel stateModel,
+        @Schema(description = "The Result of Domain Typosquatting Validation")
+        DomainTyposquattingValidationResults typosquattingValidationResults
+) {
+}

--- a/src/main/java/tech/mayanksoni/threatdetectionbackend/models/StateModel.java
+++ b/src/main/java/tech/mayanksoni/threatdetectionbackend/models/StateModel.java
@@ -1,0 +1,13 @@
+package tech.mayanksoni.threatdetectionbackend.models;
+
+import java.time.Instant;
+
+public record StateModel(
+        String state,
+        String domainName,
+        String ipAddress,
+        boolean accessAllowed,
+        boolean accessOverrideControlAvailable,
+        Instant stateExpiresAt
+) {
+}

--- a/src/main/java/tech/mayanksoni/threatdetectionbackend/models/StateModel.java
+++ b/src/main/java/tech/mayanksoni/threatdetectionbackend/models/StateModel.java
@@ -1,13 +1,21 @@
 package tech.mayanksoni.threatdetectionbackend.models;
 
-import java.time.Instant;
+import io.swagger.v3.oas.annotations.media.Schema;
 
+import java.time.Instant;
+@Schema
 public record StateModel(
+        @Schema(description = "The state id which is a unique identifier for the domain and the ip check", example = "UUID-1234-5678-90AB-CDEF12345678")
         String state,
+        @Schema(description = "The domain name for which the state is created", example = "example.com")
         String domainName,
+        @Schema(description = "The ip address for which the state is created", example = "127.0.0.1")
         String ipAddress,
+        @Schema(description = "Is access already allowed for this state", example = "false")
         boolean accessAllowed,
+        @Schema(description = "Is access override control available for this state", example = "true")
         boolean accessOverrideControlAvailable,
+        @Schema(description = "The time at which the state expires", example = "2022-01-01T00:00:00Z")
         Instant stateExpiresAt
 ) {
 }

--- a/src/main/java/tech/mayanksoni/threatdetectionbackend/processor/DomainCheckProcessor.java
+++ b/src/main/java/tech/mayanksoni/threatdetectionbackend/processor/DomainCheckProcessor.java
@@ -2,6 +2,7 @@ package tech.mayanksoni.threatdetectionbackend.processor;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.http.client.reactive.AbstractClientHttpConnectorProperties;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -24,6 +25,7 @@ public class DomainCheckProcessor {
     private final TyposquattingDetectionService typosquattingDetectionService;
     private final StateManagementService stateManagementService;
     private final ThreatDetectionConfig threatDetectionConfig;
+    private final AbstractClientHttpConnectorProperties abstractClientHttpConnectorProperties;
 
     /**
      * Checks a single domain for typosquatting.
@@ -32,7 +34,7 @@ public class DomainCheckProcessor {
      * @param stateId the state UUID associated with the domain check
      * @return A Mono containing the validation results
      */
-    public Mono<DomainValidationResponse> checkDomain(String domainName, String stateId) {
+    public Mono<DomainValidationResponse> checkDomain(String domainName, String stateId, String ipAddress) {
         log.info("Checking domain for typosquatting: {}", domainName);
         return stateManagementService.getStateById(stateId).map(state -> {
             if(state.accessAllowed()){
@@ -46,7 +48,8 @@ public class DomainCheckProcessor {
                     .build();
         }).switchIfEmpty(typosquattingDetectionService.checkDomainForTypoSquatting(domainName).flatMap(result -> {
             log.info("Domain {} checked for typosquatting, results: {}", domainName, result);
-            return stateManagementService.createStateModel(stateId, domainName, null, false)
+            boolean accessAllowed = !result.isTyposquatted() || !result.isPhoneticMatch();
+            return stateManagementService.createStateModel(stateId, domainName, ipAddress, false,accessAllowed)
                     .map(stateModel -> DomainValidationResponse.builder()
                             .stateModel(stateModel)
                             .typosquattingValidationResults(result)

--- a/src/main/java/tech/mayanksoni/threatdetectionbackend/processor/DomainCheckProcessor.java
+++ b/src/main/java/tech/mayanksoni/threatdetectionbackend/processor/DomainCheckProcessor.java
@@ -7,6 +7,8 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import tech.mayanksoni.threatdetectionbackend.configuration.ThreatDetectionConfig;
 import tech.mayanksoni.threatdetectionbackend.models.DomainTyposquattingValidationResults;
+import tech.mayanksoni.threatdetectionbackend.models.DomainValidationResponse;
+import tech.mayanksoni.threatdetectionbackend.services.StateManagementService;
 import tech.mayanksoni.threatdetectionbackend.services.TyposquattingDetectionService;
 
 import java.util.List;
@@ -20,19 +22,37 @@ import java.util.List;
 @RequiredArgsConstructor
 public class DomainCheckProcessor {
     private final TyposquattingDetectionService typosquattingDetectionService;
+    private final StateManagementService stateManagementService;
     private final ThreatDetectionConfig threatDetectionConfig;
 
     /**
      * Checks a single domain for typosquatting.
      * 
      * @param domainName The domain name to check
+     * @param stateId the state UUID associated with the domain check
      * @return A Mono containing the validation results
      */
-    public Mono<DomainTyposquattingValidationResults> checkDomain(String domainName) {
+    public Mono<DomainValidationResponse> checkDomain(String domainName, String stateId) {
         log.info("Checking domain for typosquatting: {}", domainName);
-        return typosquattingDetectionService.checkDomainForTypoSquatting(domainName);
-    }
-
+        return stateManagementService.getStateById(stateId).map(state -> {
+            if(state.accessAllowed()){
+                log.info("Access allowed for domain: {} by state id : {}", domainName, stateId);
+            }else{
+                log.info("Access not allowed for domain: {} by state id : {}", domainName, stateId);
+            }
+            return DomainValidationResponse.builder()
+                    .stateModel(state)
+                    .typosquattingValidationResults(null)
+                    .build();
+        }).switchIfEmpty(typosquattingDetectionService.checkDomainForTypoSquatting(domainName).flatMap(result -> {
+            log.info("Domain {} checked for typosquatting, results: {}", domainName, result);
+            return stateManagementService.createStateModel(stateId, domainName, null, false)
+                    .map(stateModel -> DomainValidationResponse.builder()
+                            .stateModel(stateModel)
+                            .typosquattingValidationResults(result)
+                            .build());
+        })).doOnError(e -> log.error("Error checking domain {} for typosquatting: {}", domainName, e.getMessage()));
+        }
     /**
      * Checks multiple domains for typosquatting in parallel.
      * The processing will be done in parallel if parallel processing is enabled in the configuration.
@@ -55,7 +75,7 @@ public class DomainCheckProcessor {
             // Split the list into batches
             return Flux.fromIterable(domainNames)
                     .buffer(threatDetectionConfig.getBatchSize())
-                    .flatMap(batch -> typosquattingDetectionService.checkDomainsForTypoSquattingInParallel(batch));
+                    .flatMap(typosquattingDetectionService::checkDomainsForTypoSquattingInParallel);
         }
 
         // Process the entire list at once if it's small enough

--- a/src/main/java/tech/mayanksoni/threatdetectionbackend/services/StateManagementService.java
+++ b/src/main/java/tech/mayanksoni/threatdetectionbackend/services/StateManagementService.java
@@ -1,0 +1,38 @@
+package tech.mayanksoni.threatdetectionbackend.services;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+import tech.mayanksoni.threatdetectionbackend.dm.StateDataManager;
+import tech.mayanksoni.threatdetectionbackend.models.StateModel;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class StateManagementService {
+    private final StateDataManager stateDataManager;
+
+    /**
+     * Creates a new state with the given parameters.
+     *
+     * @param state The state identifier.
+     * @param domainName The domain name associated with the state.
+     * @param ipAddress The IP address associated with the state.
+     * @param accessOverrideControlAvailable Whether access override control is available for this state.
+     * @return A Mono containing the created state model.
+     */
+    public Mono<StateModel> createStateModel(String state, String domainName, String ipAddress, boolean accessOverrideControlAvailable) {
+        log.info("Creating state model with ID: {}, Domain: {}, IP: {}, Access Override Control Available: {}",
+                state, domainName, ipAddress, accessOverrideControlAvailable);
+        return stateDataManager.createState(state, domainName, ipAddress, accessOverrideControlAvailable);
+    }
+    public Mono<StateModel> getStateById(String state){
+        log.info("Retrieving state model with ID: {}", state);
+        return stateDataManager.getStateById(state);
+    }
+    public Mono<StateModel> updateStateById(String state, boolean accessAllowed){
+        log.info("Updating state model with ID: {}, Access Allowed: {}", state, accessAllowed);
+        return stateDataManager.updateStateById(state, accessAllowed);
+    }
+}

--- a/src/main/java/tech/mayanksoni/threatdetectionbackend/services/StateManagementService.java
+++ b/src/main/java/tech/mayanksoni/threatdetectionbackend/services/StateManagementService.java
@@ -22,10 +22,10 @@ public class StateManagementService {
      * @param accessOverrideControlAvailable Whether access override control is available for this state.
      * @return A Mono containing the created state model.
      */
-    public Mono<StateModel> createStateModel(String state, String domainName, String ipAddress, boolean accessOverrideControlAvailable) {
+    public Mono<StateModel> createStateModel(String state, String domainName, String ipAddress, boolean accessOverrideControlAvailable, boolean accessAllowed) {
         log.info("Creating state model with ID: {}, Domain: {}, IP: {}, Access Override Control Available: {}",
                 state, domainName, ipAddress, accessOverrideControlAvailable);
-        return stateDataManager.createState(state, domainName, ipAddress, accessOverrideControlAvailable);
+        return stateDataManager.createState(state, domainName, ipAddress, accessOverrideControlAvailable, accessAllowed);
     }
     public Mono<StateModel> getStateById(String state){
         log.info("Retrieving state model with ID: {}", state);

--- a/src/main/java/tech/mayanksoni/threatdetectionbackend/utils/TimeProcessor.java
+++ b/src/main/java/tech/mayanksoni/threatdetectionbackend/utils/TimeProcessor.java
@@ -6,11 +6,14 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class TimeProcessor {
-    private static final Pattern TIME_PATTERN = Pattern.compile("^(\\\\d+)([a-zA-Z])$");
+    private static final Pattern TIME_PATTERN = Pattern.compile("^(\\d+)([a-zA-Z])$");
     public static Instant processTime(String timeString){
         Matcher timePatternMatcher = TIME_PATTERN.matcher(timeString);
+        if(!timePatternMatcher.matches()){
+            throw new IllegalArgumentException("Invalid time format: " + timeString + ". Expected format: <number><unit> (e.g., 5d, 2h, 30m, 15s)");
+        }
         int timeValue = Integer.parseInt(timePatternMatcher.group(1));
-        char timeUnit = timePatternMatcher.group(2).charAt(0);
+        char timeUnit = timePatternMatcher.group(2).toLowerCase().charAt(0);
         return Instant.now().plus(timeValue, getChronoUnit(timeUnit));
     }
 

--- a/src/main/java/tech/mayanksoni/threatdetectionbackend/utils/TimeProcessor.java
+++ b/src/main/java/tech/mayanksoni/threatdetectionbackend/utils/TimeProcessor.java
@@ -1,0 +1,27 @@
+package tech.mayanksoni.threatdetectionbackend.utils;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class TimeProcessor {
+    private static final Pattern TIME_PATTERN = Pattern.compile("^(\\\\d+)([a-zA-Z])$");
+    public static Instant processTime(String timeString){
+        Matcher timePatternMatcher = TIME_PATTERN.matcher(timeString);
+        int timeValue = Integer.parseInt(timePatternMatcher.group(1));
+        char timeUnit = timePatternMatcher.group(2).charAt(0);
+        return Instant.now().plus(timeValue, getChronoUnit(timeUnit));
+    }
+
+    private static ChronoUnit getChronoUnit(char timeString){
+        return switch (timeString) {
+            case 'd' -> ChronoUnit.DAYS;
+            case 'h' -> ChronoUnit.HOURS;
+            case 'm' -> ChronoUnit.MINUTES;
+            case 's' -> ChronoUnit.SECONDS;
+            default -> throw new IllegalArgumentException("Invalid time unit: " + timeString);
+        };
+    }
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -7,6 +7,7 @@ spring.data.mongodb.auto-index-creation=true
 server.forward-headers-strategy=framework
 #Threat Detection Configuration
 threatdetection.edit-distance-threshold=2
+threatdetection.default-state-lifetime=24h
 # Phonetic Matching Configuration
 threatdetection.enable-phonetic-matching=true
 threatdetection.enable-soundex=true

--- a/src/test/java/tech/mayanksoni/threatdetectionbackend/processor/DomainCheckProcessorTest.java
+++ b/src/test/java/tech/mayanksoni/threatdetectionbackend/processor/DomainCheckProcessorTest.java
@@ -7,9 +7,18 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
+import tech.mayanksoni.threatdetectionbackend.configuration.ThreatDetectionConfig;
 import tech.mayanksoni.threatdetectionbackend.models.DomainTyposquattingValidationResults;
+import tech.mayanksoni.threatdetectionbackend.models.DomainValidationResponse;
+import tech.mayanksoni.threatdetectionbackend.models.StateModel;
+import tech.mayanksoni.threatdetectionbackend.services.StateManagementService;
 import tech.mayanksoni.threatdetectionbackend.services.TyposquattingDetectionService;
 
+import java.time.Instant;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -18,6 +27,12 @@ class DomainCheckProcessorTest {
     @Mock
     private TyposquattingDetectionService typosquattingDetectionService;
 
+    @Mock
+    private StateManagementService stateManagementService;
+
+    @Mock
+    private ThreatDetectionConfig threatDetectionConfig;
+
     @InjectMocks
     private DomainCheckProcessor domainCheckProcessor;
 
@@ -25,6 +40,7 @@ class DomainCheckProcessorTest {
     void checkDomain_shouldReturnMonoWithResults() {
         // Given
         String domainName = "example.com";
+        String stateId = UUID.randomUUID().toString();
         boolean isTyposquatted = true;
         String closestMatchingDomain = "exampie.com";
         int editDistance = 1;
@@ -32,19 +48,38 @@ class DomainCheckProcessorTest {
         DomainTyposquattingValidationResults mockResults = new DomainTyposquattingValidationResults(
                 isTyposquatted, domainName, closestMatchingDomain, editDistance);
 
+        // Mock state management service to return empty (no existing state)
+        when(stateManagementService.getStateById(stateId))
+                .thenReturn(Mono.empty());
+
+        // Mock typosquatting detection service
         when(typosquattingDetectionService.checkDomainForTypoSquatting(domainName))
                 .thenReturn(Mono.just(mockResults));
 
+        // Mock state creation
+        StateModel mockStateModel = new StateModel(
+                stateId, domainName, null, false, false, Instant.now().plusSeconds(86400)
+        );
+        when(stateManagementService.createStateModel(any(), eq(domainName), any(), eq(false)))
+                .thenReturn(Mono.just(mockStateModel));
+
         // When
-        Mono<DomainTyposquattingValidationResults> result = domainCheckProcessor.checkDomain(domainName);
+        Mono<DomainValidationResponse> result = domainCheckProcessor.checkDomain(domainName, stateId);
 
         // Then
         StepVerifier.create(result)
-                .expectNextMatches(validationResults -> 
-                        validationResults.isTyposquatted() == isTyposquatted && 
-                        validationResults.domainName().equals(domainName) &&
-                        validationResults.closestMatchingDomain().equals(closestMatchingDomain) &&
-                        validationResults.editDistance() == editDistance)
+                .expectNextMatches(response -> {
+                    DomainTyposquattingValidationResults validationResults = response.typosquattingValidationResults();
+                    StateModel stateModel = response.stateModel();
+                    return validationResults != null &&
+                           validationResults.isTyposquatted() == isTyposquatted && 
+                           validationResults.domainName().equals(domainName) &&
+                           validationResults.closestMatchingDomain().equals(closestMatchingDomain) &&
+                           validationResults.editDistance() == editDistance &&
+                           stateModel != null &&
+                           stateModel.state().equals(stateId) &&
+                           stateModel.domainName().equals(domainName);
+                })
                 .verifyComplete();
     }
 
@@ -52,12 +87,18 @@ class DomainCheckProcessorTest {
     void checkDomain_shouldHandleEmptyMono() {
         // Given
         String domainName = "example.com";
+        String stateId = UUID.randomUUID().toString();
 
+        // Mock state management service to return empty (no existing state)
+        when(stateManagementService.getStateById(stateId))
+                .thenReturn(Mono.empty());
+
+        // Mock typosquatting detection service to return empty
         when(typosquattingDetectionService.checkDomainForTypoSquatting(domainName))
                 .thenReturn(Mono.empty());
 
         // When
-        Mono<DomainTyposquattingValidationResults> result = domainCheckProcessor.checkDomain(domainName);
+        Mono<DomainValidationResponse> result = domainCheckProcessor.checkDomain(domainName, stateId);
 
         // Then
         StepVerifier.create(result)

--- a/src/test/java/tech/mayanksoni/threatdetectionbackend/processor/DomainCheckProcessorTest.java
+++ b/src/test/java/tech/mayanksoni/threatdetectionbackend/processor/DomainCheckProcessorTest.java
@@ -43,6 +43,7 @@ class DomainCheckProcessorTest {
         String stateId = UUID.randomUUID().toString();
         boolean isTyposquatted = true;
         String closestMatchingDomain = "exampie.com";
+        String ipAddress = "127.0.0.1";
         int editDistance = 1;
 
         DomainTyposquattingValidationResults mockResults = new DomainTyposquattingValidationResults(
@@ -60,11 +61,11 @@ class DomainCheckProcessorTest {
         StateModel mockStateModel = new StateModel(
                 stateId, domainName, null, false, false, Instant.now().plusSeconds(86400)
         );
-        when(stateManagementService.createStateModel(any(), eq(domainName), any(), eq(false)))
+        when(stateManagementService.createStateModel(any(), eq(domainName), any(), eq(false),eq(false)))
                 .thenReturn(Mono.just(mockStateModel));
 
         // When
-        Mono<DomainValidationResponse> result = domainCheckProcessor.checkDomain(domainName, stateId);
+        Mono<DomainValidationResponse> result = domainCheckProcessor.checkDomain(domainName, stateId, ipAddress);
 
         // Then
         StepVerifier.create(result)
@@ -98,7 +99,7 @@ class DomainCheckProcessorTest {
                 .thenReturn(Mono.empty());
 
         // When
-        Mono<DomainValidationResponse> result = domainCheckProcessor.checkDomain(domainName, stateId);
+        Mono<DomainValidationResponse> result = domainCheckProcessor.checkDomain(domainName, stateId, null);
 
         // Then
         StepVerifier.create(result)


### PR DESCRIPTION
This pull request introduces significant enhancements to the threat detection backend, primarily focusing on state management and domain validation. Key changes include the addition of state management functionality, updates to domain validation logic, and the introduction of new models and data mapping. Below is a breakdown of the most important changes grouped by theme.

### State Management Enhancements:
* Introduced `StateDataManager` interface for managing state-related operations, including creating, retrieving, updating, and deleting states.
* Added `StateMongoDataManagerImpl` implementation to handle state persistence in MongoDB, including cleanup tasks for inactive states.
* Created `StateDocument` to represent state entities in MongoDB, with fields for state ID, domain name, IP address, timestamps, and access control flags.
* Added `StateManagementService` to abstract state-related operations and provide business logic for state creation and retrieval.

### Domain Validation Updates:
* Updated `CheckDomainController` to support both GET and POST methods for domain validation, with POST accepting a `DomainValidationRequest` body.
* Changed response schema from `DomainTyposquattingValidationResults` to `DomainValidationResponse` to include state information alongside validation results.
* Enhanced `DomainCheckProcessor` to integrate state management, allowing state-based access control during domain validation.

### New Models and Mappers:
* Added `DomainValidationRequest` and `DomainValidationResponse` models for handling domain validation inputs and outputs. [[1]](diffhunk://#diff-52a163a9142982c5eaeb9ddfd47472eba8498412ced334bc4fca225aa3742608R1-R8) [[2]](diffhunk://#diff-d4ac88127072f7a3b7beb1de51227b7c160bf086398430d38686cb9f388a61f8R1-R14)
* Introduced `StateModel` to represent state data in the application layer, mapped from `StateDocument`.
* Created `StateMapper` using MapStruct to convert between `StateDocument` and `StateModel`.

### Miscellaneous Updates:
* Renamed `TrustedDomainMongoDataManagerImpl` to reflect its MongoDB-specific implementation.
* Added a default state lifetime configuration (`defaultStateLifetime`) to `ThreatDetectionConfig`.

These changes collectively enhance the backend's ability to manage states and validate domains with more robust and scalable functionality.